### PR TITLE
Pin NumPy < 1.23 due to scikits.odes incompatibility.

### DIFF
--- a/multibody-book-env.yml
+++ b/multibody-book-env.yml
@@ -6,7 +6,7 @@ dependencies:
   - graphviz
   - jupyter-sphinx
   - matplotlib
-  - numpy
+  - numpy <1.23  # scikits.odes 2.6.3 breaks with numpy 1.23
   - python ==3.9.*
   - pythreejs
   - scikits.odes


### PR DESCRIPTION
See: https://github.com/bmcage/odes/pull/136 where the issues has been
fixed in scikits.odes. The next release will work with NumPy 1.23.

Fixes #88