### PR TITLE
Use sphinxcontrib.youtube

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -39,6 +39,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.todo',
+    'sphinxcontrib.youtube',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/jupyter-python.rst
+++ b/jupyter-python.rst
@@ -481,12 +481,8 @@ https://realPython.com/jupyter-notebook-introduction/
 
 This 7 minute video also gives the basics:
 
-.. raw:: html
-
-   <iframe width="560" height="315"
-   src="https://www.youtube.com/embed/jZ952vChhuI" title="YouTube video player"
-   frameborder="0" allow="accelerometer; autoplay; clipboard-write;
-   encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+.. youtube:: jZ952vChhuI
+   :align: center
 
 More Python
 -----------

--- a/motion.rst
+++ b/motion.rst
@@ -468,14 +468,8 @@ nonholonomic locomotion [Ostrowski1994]_. Similar to the Chaplygin Sleigh, the
 wheels can generally only travel in the direction they are pointed. This
 classic video from 1993 shows how to propel the board:
 
-.. raw:: html
-
-   <center>
-   <iframe width="560" height="315"
-   src="https://www.youtube.com/embed/yxlC95YjmEs" title="YouTube video player"
-   frameborder="0" allow="accelerometer; autoplay; clipboard-write;
-   encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-   </center>
+.. youtube:: yxlC95YjmEs
+   :align: center
 
 .. _snakeboard: https://en.wikipedia.org/wiki/Snakeboard
 

--- a/multibody-book-env.yml
+++ b/multibody-book-env.yml
@@ -16,4 +16,5 @@ dependencies:
   - sphinx-autobuild  # dev
   - sphinx-material ==0.0.35
   - sphinx-togglebutton ==0.3.1
+  - sphinxcontrib-youtube ==1.2.0
   - sympy ==1.11.1

--- a/orientation.rst
+++ b/orientation.rst
@@ -724,19 +724,9 @@ space.
 Watch this video to get a sense of the orientation axes for each intermediate
 auxiliary reference frame:
 
-.. raw:: html
-
-   <center>
-      <iframe
-        width="560"
-        height="315"
-        src="https://www.youtube.com/embed/xQMBIXqWcjI?start=177"
-        title="YouTube video player"
-        frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen>
-      </iframe>
-   </center>
+.. youtube:: xQMBIXqWcjI
+   :align: center
+   :url_parameters: "?start=177"
 
 We first orient :math:`B` with respect to :math:`A` about the shared :math:`z`
 unit vector through the angle :math:`\psi`, as shown below:

--- a/sympy.rst
+++ b/sympy.rst
@@ -1119,12 +1119,8 @@ https://docs.sympy.org, where you will find general information on SymPy.
 
 The tutorial is also available on video:
 
-.. raw:: html
-
-   <iframe width="560" height="315"
-   src="https://www.youtube.com/embed/AqnpuGbM6-Q" title="YouTube video player"
-   frameborder="0" allow="accelerometer; autoplay; clipboard-write;
-   encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+.. youtube:: AqnpuGbM6-Q
+   :align: center
 
 If you want to ask a question about using SymPy (or search to see if someone
 else has asked your question), you can do so at the following places:


### PR DESCRIPTION
Attempt at solving #86.

Some issues:

- The start time parameter does not seem to work, i.e. `url_parameters` is not picked up and appended.
- Does not support playlists, see https://github.com/sphinx-contrib/youtube/issues/37

The PDF build includes links to the youtube videos:

![image](https://user-images.githubusercontent.com/276007/219848468-eab7ade7-da9a-484f-b325-929675183546.png)

I could probably achieve that manually. Not sure this extension is worth adding.